### PR TITLE
Corregido bug que no permitia setear excluded_channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $paymentRequest = $sdk->paymentRequests->create($paymentRequest);
 Para facilitar la exclusión de canales, se proveen constantes dentro de la clase `\Pagos360\Constants`. Como la plataforma de Pagos360 se encuentra en desarrollo activo, es probable que en el futuro se agreguen más tipos de canales que aun no estén soportados en el SDK. En ese caso, se puede usar una string representando el nuevo valor.
 
 ```php
-$paymentRequest->setExcludedChannelTypes([
+$paymentRequest->setExcludedChannels([
     \Pagos360\Constants::CHANNEL_CREDIT_CARD,
     'tipo_de_canal_nuevo',
 ]);

--- a/src/Models/PaymentRequest.php
+++ b/src/Models/PaymentRequest.php
@@ -156,7 +156,7 @@ class PaymentRequest extends AbstractModel
      *
      * @var string[]|null
      */
-    protected $excludedChannelTypes;
+    protected $excludedChannels;
 
     /**
      * @var HolderData|null
@@ -443,18 +443,18 @@ class PaymentRequest extends AbstractModel
     /**
      * @return string[]|null
      */
-    public function getExcludedChannelTypes(): ?array
+    public function getExcludedChannels(): ?array
     {
-        return $this->excludedChannelTypes;
+        return $this->excludedChannels;
     }
 
     /**
-     * @param string[]|null $excludedChannelTypes
+     * @param string[]|null $excludedChannels
      * @return self
      */
-    public function setExcludedChannelTypes(?array $excludedChannelTypes): self
+    public function setExcludedChannels(?array $excludedChannels): self
     {
-        $this->excludedChannelTypes = $excludedChannelTypes;
+        $this->excludedChannels = $excludedChannels;
         return $this;
     }
 

--- a/src/Repositories/PaymentRequestRepository.php
+++ b/src/Repositories/PaymentRequestRepository.php
@@ -102,9 +102,9 @@ class PaymentRequestRepository extends AbstractRepository
             self::TYPE => Types::URL,
             self::PROPERTY_PATH => 'back_url_rejected',
         ],
-        'excludedChannelTypes' => [
+        'excludedChannels' => [
             self::TYPE => Types::ARRAY_OF_STRINGS,
-            self::PROPERTY_PATH => 'excluded_channel_types',
+            self::PROPERTY_PATH => 'excluded_channels',
         ],
         'holderData' => [
             self::FLAG_READONLY => true,


### PR DESCRIPTION
Se corrigió el SDK para que funcione correctamente el parámetro excluded_channels, y se actualizá la documentacián acorde a los cambios.