### PR TITLE
Moved common methods between Adhesion and CardAdhesion into new AbstractAdhesion class

### DIFF
--- a/src/Models/AbstractAdhesion.php
+++ b/src/Models/AbstractAdhesion.php
@@ -98,9 +98,9 @@ class AbstractAdhesion extends AbstractModel {
 
     /**
      * @param string $email
-     * @return CardAdhesion
+     * @return self
      */
-    public function setEmail(string $email): CardAdhesion
+    public function setEmail(string $email): self
     {
         $this->email = $email;
         return $this;
@@ -116,9 +116,9 @@ class AbstractAdhesion extends AbstractModel {
 
     /**
      * @param string $description
-     * @return CardAdhesion
+     * @return self
      */
-    public function setDescription(string $description): CardAdhesion
+    public function setDescription(string $description): self
     {
         $this->description = $description;
         return $this;
@@ -177,9 +177,9 @@ class AbstractAdhesion extends AbstractModel {
 
     /**
      * @param string $externalReference
-     * @return CardAdhesion
+     * @return self
      */
-    public function setExternalReference(string $externalReference): CardAdhesion
+    public function setExternalReference(string $externalReference): self
     {
         $this->externalReference = $externalReference;
         return $this;

--- a/src/Models/AbstractAdhesion.php
+++ b/src/Models/AbstractAdhesion.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Pagos360\Models;
+
+class AbstractAdhesion extends AbstractModel {
+    /**
+     * ID de Adhesión.
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * Estado de la Adhesión.
+     * Los posibles valores son: "pending_to_sign", "signed", "canceled".
+     *
+     * @var string
+     */
+    protected $state;
+
+    /**
+     * Fecha y hora de creación.
+     *
+     * @var \DateTimeInterface
+     */
+    protected $createdAt;
+
+    /**
+     * Nombre del titular del servicio que se debitará.
+     *
+     * @var string
+     */
+    protected $adhesionHolderName;
+
+    /**
+     * Motivo de cancelación de una Adhesión.
+     *
+     * @var string|null
+     */
+    protected $stateComment;
+
+    /**
+     * Fecha y hora de cancelación. Si está presente, este valor
+     * indica la fecha en que la adhesion ha sido cancelada.
+     *
+     * @var \DateTimeInterface|null
+     */
+    protected $canceledAt;
+
+    /**
+     * Objeto JSON que se puede utilizar para guardar atributos adicionales en
+     * la adhesión y poder sincronizar con tus sistemas de backend.
+     * Pagos360.com no utiliza este objeto.
+     *
+     * @var array|null
+     */
+    protected $metadata;
+
+    /**
+     * Descripción o concepto de la Adhesión.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * Email del del titular de la cuenta bancaria.
+     *
+     * @var string
+     */
+    protected $email;
+
+    /**
+     * Este atributo se puede utilizar como referencia para identificar la
+     * Adhesión y sincronizar con tus sistemas de backend el origen de
+     * la operación. Algunos valores comunmente utilizados son: ID de Cliente,
+     * DNI, CUIT, ID de venta o Nro. de Factura entre otros.
+     *
+     * @var string|null
+     */
+    protected $externalReference;
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     * @return CardAdhesion
+     */
+    public function setEmail(string $email): CardAdhesion
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     * @return CardAdhesion
+     */
+    public function setDescription(string $description): CardAdhesion
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getState(): string
+    {
+        return $this->state;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getCanceledAt(): ?\DateTimeInterface
+    {
+        return $this->canceledAt;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param array|null $metadata
+     * @return self
+     */
+    public function setMetadata(?array $metadata): self
+    {
+        $this->metadata = $metadata;
+        return $this;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getExternalReference(): string
+    {
+        return $this->externalReference;
+    }
+
+    /**
+     * @param string $externalReference
+     * @return CardAdhesion
+     */
+    public function setExternalReference(string $externalReference): CardAdhesion
+    {
+        $this->externalReference = $externalReference;
+        return $this;
+    }
+
+
+
+}

--- a/src/Models/Adhesion.php
+++ b/src/Models/Adhesion.php
@@ -2,8 +2,25 @@
 
 namespace Pagos360\Models;
 
+
+/**
+ * @method self setDescription(string $description)
+ * @method self setExternalReference(string $externalReference)
+ * @method self setEmail(string $email)
+ * @method int getId()
+ * @method string getEmail()
+ * @method string getDescription()
+ * @method string getState()
+ * @method DateTimeInterface getCreatedAt()
+ * @method DateTimeInterface getCanceledAt()
+ * @method ?array getMetadata()
+ * @method self setMetadata(?array $metadata)
+ * @method string getExternalReference()
+ */
+
 class Adhesion extends AbstractAdhesion
 {
+
     /**
      * Número de CBU de la cuenta bancaria en la que se ejecutarán los débitos.
      *
@@ -50,9 +67,9 @@ class Adhesion extends AbstractAdhesion
 
     /**
      * @param string $adhesionHolderName
-     * @return self
+     * @return Adhesion
      */
-    public function setAdhesionHolderName(string $adhesionHolderName): self
+    public function setAdhesionHolderName(string $adhesionHolderName): Adhesion
     {
         $this->adhesionHolderName = $adhesionHolderName;
         return $this;
@@ -68,9 +85,9 @@ class Adhesion extends AbstractAdhesion
 
     /**
      * @param string $cbuNumber
-     * @return self
+     * @return Adhesion
      */
-    public function setCbuNumber(string $cbuNumber): self
+    public function setCbuNumber(string $cbuNumber): Adhesion
     {
         $this->cbuNumber = $cbuNumber;
         return $this;
@@ -86,9 +103,9 @@ class Adhesion extends AbstractAdhesion
 
     /**
      * @param int $cbuHolderIdNumber
-     * @return self
+     * @return Adhesion
      */
-    public function setCbuHolderIdNumber(int $cbuHolderIdNumber): self
+    public function setCbuHolderIdNumber(int $cbuHolderIdNumber): Adhesion
     {
         $this->cbuHolderIdNumber = $cbuHolderIdNumber;
         return $this;
@@ -104,9 +121,9 @@ class Adhesion extends AbstractAdhesion
 
     /**
      * @param string $cbuHolderName
-     * @return self
+     * @return Adhesion
      */
-    public function setCbuHolderName(string $cbuHolderName): self
+    public function setCbuHolderName(string $cbuHolderName): Adhesion
     {
         $this->cbuHolderName = $cbuHolderName;
         return $this;
@@ -130,9 +147,9 @@ class Adhesion extends AbstractAdhesion
 
     /**
      * @param string $shortDescription
-     * @return self
+     * @return Adhesion
      */
-    public function setShortDescription(string $shortDescription): self
+    public function setShortDescription(string $shortDescription): Adhesion
     {
         $this->shortDescription = $shortDescription;
         return $this;

--- a/src/Models/Adhesion.php
+++ b/src/Models/Adhesion.php
@@ -2,47 +2,8 @@
 
 namespace Pagos360\Models;
 
-class Adhesion extends AbstractModel
+class Adhesion extends AbstractAdhesion
 {
-    /**
-     * ID de Adhesión.
-     *
-     * @var int
-     */
-    protected $id;
-
-    /**
-     * Estado de la Adhesión.
-     * Los posibles valores son: "pending_to_sign", "signed", "canceled".
-     *
-     * @var string
-     */
-    protected $state;
-
-    /**
-     * Fecha y hora de creación.
-     *
-     * @var \DateTimeInterface
-     */
-    protected $createdAt;
-
-    /**
-     * Nombre del titular del servicio que se debitará.
-     *
-     * @var string
-     */
-    protected $adhesionHolderName;
-
-    /**
-     * Este atributo se puede utilizar como referencia para identificar la
-     * Adhesión y sincronizar con tus sistemas de backend el origen de
-     * la operación. Algunos valores comunmente utilizados son: ID de Cliente,
-     * DNI, CUIT, ID de venta o Nro. de Factura entre otros.
-     *
-     * @var string|null
-     */
-    protected $externalReference;
-
     /**
      * Número de CBU de la cuenta bancaria en la que se ejecutarán los débitos.
      *
@@ -65,25 +26,11 @@ class Adhesion extends AbstractModel
     protected $cbuHolderName;
 
     /**
-     * Email del del titular de la cuenta bancaria.
-     *
-     * @var string
-     */
-    protected $email;
-
-    /**
      * Nombre de la entidad bancaria a la que corresponde el número de CBU.
      *
      * @var string
      */
     protected $bank;
-
-    /**
-     * Descripción o concepto de la Adhesión.
-     *
-     * @var string
-     */
-    protected $description;
 
     /**
      * Descripción Bancaria que se mostrará en el resumen de la cuenta bancaria
@@ -92,55 +39,6 @@ class Adhesion extends AbstractModel
      * @var string
      */
     protected $shortDescription;
-
-    /**
-     * Fecha y hora de cancelación. Si está presente, este valor
-     * indica la fecha en que la adhesion ha sido cancelada.
-     *
-     * @var \DateTimeInterface|null
-     */
-    protected $canceledAt;
-
-    /**
-     * Motivo de cancelación de una Adhesión. Si está presente, este valor
-     * indica por qué la adhesion ha sido cancelada.
-     *
-     * @var string|null
-     */
-    protected $stateComment;
-
-    /**
-     * Objeto JSON que se puede utilizar para guardar atributos adicionales en
-     * la adhesion y poder sincronizar con tus sistemas de backend. Pagos360 no
-     * utiliza este objeto.
-     *
-     * @var array|null
-     */
-    protected $metadata;
-
-    /**
-     * @return int
-     */
-    public function getId(): int
-    {
-        return $this->id;
-    }
-
-    /**
-     * @return string
-     */
-    public function getState(): string
-    {
-        return $this->state;
-    }
-
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getCreatedAt(): \DateTimeInterface
-    {
-        return $this->createdAt;
-    }
 
     /**
      * @return string
@@ -157,24 +55,6 @@ class Adhesion extends AbstractModel
     public function setAdhesionHolderName(string $adhesionHolderName): self
     {
         $this->adhesionHolderName = $adhesionHolderName;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getExternalReference(): ?string
-    {
-        return $this->externalReference;
-    }
-
-    /**
-     * @param string|null $externalReference
-     * @return self
-     */
-    public function setExternalReference(?string $externalReference): self
-    {
-        $this->externalReference = $externalReference;
         return $this;
     }
 
@@ -235,45 +115,9 @@ class Adhesion extends AbstractModel
     /**
      * @return string
      */
-    public function getEmail(): string
-    {
-        return $this->email;
-    }
-
-    /**
-     * @param string $email
-     * @return self
-     */
-    public function setEmail(string $email): self
-    {
-        $this->email = $email;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
     public function getBank(): string
     {
         return $this->bank;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDescription(): string
-    {
-        return $this->description;
-    }
-
-    /**
-     * @param string $description
-     * @return self
-     */
-    public function setDescription(string $description): self
-    {
-        $this->description = $description;
-        return $this;
     }
 
     /**
@@ -294,13 +138,6 @@ class Adhesion extends AbstractModel
         return $this;
     }
 
-    /**
-     * @return \DateTimeInterface|null
-     */
-    public function getCanceledAt(): ?\DateTimeInterface
-    {
-        return $this->canceledAt;
-    }
 
     /**
      * @return string|null
@@ -310,21 +147,5 @@ class Adhesion extends AbstractModel
         return $this->stateComment;
     }
 
-    /**
-     * @return array|null
-     */
-    public function getMetadata(): ?array
-    {
-        return $this->metadata;
-    }
 
-    /**
-     * @param array|null $metadata
-     * @return self
-     */
-    public function setMetadata(?array $metadata): self
-    {
-        $this->metadata = $metadata;
-        return $this;
-    }
 }

--- a/src/Models/CardAdhesion.php
+++ b/src/Models/CardAdhesion.php
@@ -2,6 +2,21 @@
 
 namespace Pagos360\Models;
 
+/**
+ * @method self setDescription(string $description)
+ * @method self setExternalReference(string $externalReference)
+ * @method self setEmail(string $email)
+ * @method int getId()
+ * @method string getEmail()
+ * @method string getDescription()
+ * @method string getState()
+ * @method DateTimeInterface getCreatedAt()
+ * @method DateTimeInterface getCanceledAt()
+ * @method ?array getMetadata()
+ * @method self setMetadata(?array $metadata)
+ * @method string getExternalReference()
+ */
+
 class CardAdhesion extends AbstractAdhesion
 {
     /**

--- a/src/Models/CardAdhesion.php
+++ b/src/Models/CardAdhesion.php
@@ -2,39 +2,8 @@
 
 namespace Pagos360\Models;
 
-class CardAdhesion extends AbstractModel
+class CardAdhesion extends AbstractAdhesion
 {
-    /**
-     * Nombre del titular del servicio que se debitará.
-     *
-     * @var string
-     */
-    protected $adhesionHolderName;
-
-    /**
-     * Email del titular de la Tarjeta.
-     *
-     * @var string
-     */
-    protected $email;
-
-    /**
-     * Descripción o concepto de la Adhesión.
-     *
-     * @var string
-     */
-    protected $description;
-
-    /**
-     * Este atributo se puede utilizar como referencia para identificar la
-     * Adhesión y sincronizar con tus sistemas de backend el origen de la
-     * operación. Algunos valores comúnmente utilizados son: ID de Cliente, DNI,
-     * CUIT, ID de venta o Nro. de Factura entre otros.
-     *
-     * @var string
-     */
-    protected $externalReference;
-
     /**
      * Hash en Base64 que contiene la Encriptación del Número de Tarjeta en la
      * que se ejecutarán los débitos automáticos.
@@ -51,22 +20,6 @@ class CardAdhesion extends AbstractModel
     protected $cardHolderName;
 
     /**
-     * Objeto JSON que se puede utilizar para guardar atributos adicionales en
-     * la adhesión y poder sincronizar con tus sistemas de backend.
-     * Pagos360.com no utiliza este objeto.
-     *
-     * @var array|null
-     */
-    protected $metadata;
-
-    /**
-     * ID de Adhesión.
-     *
-     * @var int
-     */
-    protected $id;
-
-    /**
      * Ultimos 4 numeros de la Tarjeta.
      *
      * @var string
@@ -79,36 +32,6 @@ class CardAdhesion extends AbstractModel
      * @var string
      */
     protected $card;
-
-    /**
-     * Estado de la Adhesión.
-     * Los posibles valores son: "pending_to_sign", "signed", "canceled".
-     *
-     * @var string
-     */
-    protected $state;
-
-    /**
-     * Fecha y hora de creación.
-     *
-     * @var \DateTimeImmutable
-     */
-    protected $createdAt;
-
-    /**
-     * Motivo de cancelación de una Adhesión.
-     *
-     * @var string|null
-     */
-    protected $stateComment;
-
-    /**
-     * Fecha y hora de cancelación. Si está presente, este valor
-     * indica la fecha en que la adhesion ha sido cancelada.
-     *
-     * @var \DateTimeImmutable|null
-     */
-    protected $canceledAt;
 
     /**
      * @return string
@@ -125,60 +48,6 @@ class CardAdhesion extends AbstractModel
     public function setAdhesionHolderName(string $adhesionHolderName): CardAdhesion
     {
         $this->adhesionHolderName = $adhesionHolderName;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEmail(): string
-    {
-        return $this->email;
-    }
-
-    /**
-     * @param string $email
-     * @return CardAdhesion
-     */
-    public function setEmail(string $email): CardAdhesion
-    {
-        $this->email = $email;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDescription(): string
-    {
-        return $this->description;
-    }
-
-    /**
-     * @param string $description
-     * @return CardAdhesion
-     */
-    public function setDescription(string $description): CardAdhesion
-    {
-        $this->description = $description;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getExternalReference(): string
-    {
-        return $this->externalReference;
-    }
-
-    /**
-     * @param string $externalReference
-     * @return CardAdhesion
-     */
-    public function setExternalReference(string $externalReference): CardAdhesion
-    {
-        $this->externalReference = $externalReference;
         return $this;
     }
 
@@ -211,32 +80,6 @@ class CardAdhesion extends AbstractModel
     }
 
     /**
-     * @return array|null
-     */
-    public function getMetadata(): ?array
-    {
-        return $this->metadata;
-    }
-
-    /**
-     * @param array $metadata
-     * @return CardAdhesion
-     */
-    public function setMetadata(array $metadata): CardAdhesion
-    {
-        $this->metadata = $metadata;
-        return $this;
-    }
-
-    /**
-     * @return int
-     */
-    public function getId(): int
-    {
-        return $this->id;
-    }
-
-    /**
      * @return string
      */
     public function getLastFourDigits(): string
@@ -253,22 +96,6 @@ class CardAdhesion extends AbstractModel
     }
 
     /**
-     * @return string
-     */
-    public function getState(): string
-    {
-        return $this->state;
-    }
-
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getCreatedAt(): \DateTimeImmutable
-    {
-        return $this->createdAt;
-    }
-
-    /**
      * @return string|null
      */
     public function getStateComment(): ?string
@@ -276,11 +103,4 @@ class CardAdhesion extends AbstractModel
         return $this->stateComment;
     }
 
-    /**
-     * @return \DateTimeImmutable|null
-     */
-    public function getCanceledAt(): ?\DateTimeImmutable
-    {
-        return $this->canceledAt;
-    }
 }


### PR DESCRIPTION
Estimados, dada la similitud (muy bienvenida) entre Adhesion y CardAdhesion, he movido todos los metodos y propiedades comunes entre ambas a una nueva clase AbstractAdhesion.
El motivo de esto es que nosotros los consumidores de la API, internamente no necesitamos mucho mas que saber el ID de una adhesion para luego consultar el estado cuando esto sea necesario.
El hecho de que ambas adhesiones hereden de una clase comun nos permite hacer algo como esto dentro de nuestros sistemas, haciendo el codigo mucho mas limpio.

```php
    // constructor del modelo p360_adhesion dentro de nuestros sistemas...
    public function __construct(AbstractAdhesion $adhesion)
    {
        // Setear tipo basado en clase
        if (is_a($adhesion, 'Adhesion')) {
            $this->type = 'bank';
        } else if (is_a($adhesion, 'CardAdhesion')) {
            $this->type = 'credit_card';
        } else {
            throw new Exception('Only objects of type AbstractAdhesion allowed.');
        }
                
        $this->status = $adhesion->getState();
        $this->adhesionId = $adhesion->getId();
        $this->updatedAt = new DateTime();
    }
```

Les pediria que por favor consideren este PR ya que no afecta en nada a quienes puedan estar usando actualmente el SDK ni rompe la API publica del SDK.

Gracias!

// Diego







